### PR TITLE
use findAndCountAll for relay pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,69 +13,81 @@
 [![GitHub issues](https://img.shields.io/github/stars/Thomas-Smyth/sequelize-cursor-pagination.svg?style=flat-square)](https://github.com/Thomas-Smyth/sequelize-cursor-pagination/stargazers)
 
 <br><br>
+
 </div>
 
 ## About
+
 `sequelize-cursor-pagination` is a Sequelize modal decorator that implements two kinds of pagination:
- * Simple Pagination - A non-formal pagination approach that is intended to be simple and easy to use.
- * Relay Pagination - A formal pagination approach that meets the [Relay GraphQL Cursor Connections Specification](https://relay.dev/graphql/connections.htm).
+
+- Simple Pagination - A non-formal pagination approach that is intended to be simple and easy to use.
+- Relay Pagination - A formal pagination approach that meets the [Relay GraphQL Cursor Connections Specification](https://relay.dev/graphql/connections.htm).
 
 This package was created to solve some minor annoyances in and simplify [Kaltsoon's sequelize-cursor-pagination](https://github.com/Kaltsoon/sequelize-cursor-pagination), however, has expanded to support the [Relay GraphQL Cursor Connections Specification](https://relay.dev/graphql/connections.htm) in order for it to be suitable for GraphQL APIs.
 
 #### Why use this package over others?
+
 There is a small number of packages out there that provide cursor based pagination queries for Sequelize. The most prominent of these is [Kaltsoon's sequelize-cursor-pagination](https://github.com/Kaltsoon/sequelize-cursor-pagination), which this package uses as a base with the intent to improve upon it.
 
- * Multiple Order Queries - [Kaltsoon's version does not support multiple order queries very well](https://github.com/Kaltsoon/sequelize-cursor-pagination/issues/17). This version allows you to input orders of any length like normal Sequelize finders, i.e. `[[field1, direction1], [field2, direction2], ...]`.
- * Common Value Support - [Kaltsoon's version does not support common values very well](https://github.com/Kaltsoon/sequelize-cursor-pagination/issues/35).  This version provides better support for common values by ensuring that ordering and comparisons of fields are robust. Furthermore, it ensures that all queries are ordered by primary key at some stage and that cursors contain the primary  key leading to unambiguous starting points for pages.
-  * Single Cursor Input/Relay GraphQL Cursor Connections Specification  - Kaltsoon's version requires you to specify whether an inputted cursor is either a `before` or `after` cursor in order for it to decide whether you are requesting the previous or next page. Although this is similar to the Relay GraphQL Cursor Connections Specification, the package is not a full implementation of the specification and therefore the two cursor input options add unnecessary complexity to the package as the caller has to specify both the cursor and the direction even though the cursor will be unique to the direction. This version simplifies this by embedding the direction in each cursor, so the caller only needs to input the appropriate cursor for the previous/next page to be returned. In addition to this, it provides an implementation that fully meets the Relay GraphQL Cursor Connections Specification for use in GraphQL APIs.
+- Multiple Order Queries - [Kaltsoon's version does not support multiple order queries very well](https://github.com/Kaltsoon/sequelize-cursor-pagination/issues/17). This version allows you to input orders of any length like normal Sequelize finders, i.e. `[[field1, direction1], [field2, direction2], ...]`.
+- Common Value Support - [Kaltsoon's version does not support common values very well](https://github.com/Kaltsoon/sequelize-cursor-pagination/issues/35). This version provides better support for common values by ensuring that ordering and comparisons of fields are robust. Furthermore, it ensures that all queries are ordered by primary key at some stage and that cursors contain the primary key leading to unambiguous starting points for pages.
+- Single Cursor Input/Relay GraphQL Cursor Connections Specification - Kaltsoon's version requires you to specify whether an inputted cursor is either a `before` or `after` cursor in order for it to decide whether you are requesting the previous or next page. Although this is similar to the Relay GraphQL Cursor Connections Specification, the package is not a full implementation of the specification and therefore the two cursor input options add unnecessary complexity to the package as the caller has to specify both the cursor and the direction even though the cursor will be unique to the direction. This version simplifies this by embedding the direction in each cursor, so the caller only needs to input the appropriate cursor for the previous/next page to be returned. In addition to this, it provides an implementation that fully meets the Relay GraphQL Cursor Connections Specification for use in GraphQL APIs.
 
 ## Install
+
 ```
 yarn add @thomas-smyth/sequelize-cursor-pagination
 ```
 
 ## Usage
+
 #### Define a Sequelize Model
+
 ##### Simple Pagination
+
 ```js
 const { withSimplePagination } = require('@thomas-smyth/sequelize-cursor-pagination');
 
 const Counter = sequelize.define('counter', {
   id: { type: Sequelize.INTEGER, primaryKey: true, autoIncrement: true },
-  value: Sequelize.INTEGER,
+  value: Sequelize.INTEGER
 });
 
 const options = {
   methodName: 'paginate',
-  primaryKeyField: 'id',
+  primaryKeyField: 'id'
 };
 
 withSimplePagination(options)(Counter);
 ```
 
 ##### Relay Pagination
+
 ```js
 const { withRelayPagination } = require('@thomas-smyth/sequelize-cursor-pagination');
 
 const Counter = sequelize.define('counter', {
   id: { type: Sequelize.INTEGER, primaryKey: true, autoIncrement: true },
-  value: Sequelize.INTEGER,
+  value: Sequelize.INTEGER
 });
 
 const options = {
   methodName: 'paginate',
-  primaryKeyField: 'id',
+  primaryKeyField: 'id'
 };
 
 withRelayPagination(options)(Counter);
 ```
 
 The `withSimplePagination`/`withRelayPagination` function has the following options:
- * `methodName` - The name of the pagination method. The default value is `paginate`.
- * `primaryKeyField` - The primary key field of the model which all queries will be ordered by last in order to ensure cursors are unique. The default value is `id`.
+
+- `methodName` - The name of the pagination method. The default value is `paginate`.
+- `primaryKeyField` - The primary key field of the model which all queries will be ordered by last in order to ensure cursors are unique. The default value is `id`.
 
 #### Call the Initial Page
+
 ##### Simple Pagination
+
 ```js
 const page = await Counter.paginate({
   where: { value: { $gt: 2 } },
@@ -84,14 +96,16 @@ const page = await Counter.paginate({
 ```
 
 The `paginate` method returns an object with the following properties:
- * `results` - An array of Sequelize model instances.
- * `cursors` - Object containing information related to cursors.
-     - `cursors.hasPrev` - Has previous value(s).
-     - `cursors.hasNext` - Has next value(s).
-     - `cursors.prevCursor` - The cursor for the previous page.
-     - `cursors.nextCursor` - The cursor for the next page.
+
+- `results` - An array of Sequelize model instances.
+- `cursors` - Object containing information related to cursors.
+  - `cursors.hasPrev` - Has previous value(s).
+  - `cursors.hasNext` - Has next value(s).
+  - `cursors.prevCursor` - The cursor for the previous page.
+  - `cursors.nextCursor` - The cursor for the next page.
 
 ##### Relay Pagination
+
 ```js
 const page = await Counter.paginate({
   where: { value: { $gt: 2 } },
@@ -100,20 +114,25 @@ const page = await Counter.paginate({
 ```
 
 The `paginate` method returns an object with the following properties:
- * `edges` - An array of edges.
-   - `edges[].cursor` - The cursor of the edge.
-   - `edges[].node` - The node of the edge.
- * `pageInfo` - Object containing information related to cursors.
-   - `pageInfo.hasPreviousPage` - Has previous value(s).
-   - `pageInfo.hasNextPage` - Has next value(s).
-   - `pageInfo.startCursor` - The cursor for the first edge page.
-   - `pageInfo.endCursor` - The cursor for the last edge page.
+
+- `totalCount` - Total number of records that match the query criteria, regardless of limit or page size.
+- `edges` - An array of edges.
+  - `edges[].cursor` - The cursor of the edge.
+  - `edges[].node` - The node of the edge.
+- `pageInfo` - Object containing information related to cursors.
+  - `pageInfo.hasPreviousPage` - Has previous value(s).
+  - `pageInfo.hasNextPage` - Has next value(s).
+  - `pageInfo.startCursor` - The cursor for the first edge page.
+  - `pageInfo.endCursor` - The cursor for the last edge page.
 
 For more information, please see the [Relay GraphQL Cursor Connections Specification](https://relay.dev/graphql/connections.htm).
 
 #### Call the Next Page
+
 ##### Simple Pagination
+
 To call the next/previous page pass the appropriate `prevCursor`/`nextCursor` values to the `cursor` option. For example, to go to the next page:
+
 ```js
 const pageOne = await Counter.paginate({
   where: { value: { $gt: 2 } },
@@ -128,7 +147,9 @@ const pageTwo = await Counter.paginate({
 ```
 
 ##### Relay Specification
+
 To call the next/previous page pass the appropriate `endCursor`/`startCursor` value to the appropriate `after`/`before` option, as well as the appropriate `first`/`last` option as a replacement to the `limit` option. For example, to go to the next page:
+
 ```js
 const pageOne = await Counter.paginate({
   where: { value: { $gt: 2 } },
@@ -149,6 +170,7 @@ The `paginate` method accepts a `paginationField` cursor that overrides the prev
 The `paginate` method _should_ also accept all the same arguments as [Sequelizer's `findAll` finder](https://sequelize.org/master/manual/model-querying-finders.html#-code-findall--code-), however, this has not been as extensively tested. Open to issues/PRs to address any issues found regarding this.
 
 ## Run Tests
+
 ```
 yarn run test
 ```

--- a/index.js
+++ b/index.js
@@ -199,7 +199,7 @@ module.exports.withRelayPagination = function ({
       }
 
       return model
-        .findAll({
+        .findAndCountAll({
           where,
           order,
           ...(limit && { limit: limit + 1 }),
@@ -217,24 +217,25 @@ module.exports.withRelayPagination = function ({
           const [hasPreviousPage, hasNextPage] =
             after || before
               ? direction === 'next'
-                ? [true, results.length > limit]
-                : [results.length > limit, true]
-              : [false, results.length > limit];
+                ? [true, results.rows.length > limit]
+                : [results.rows.length > limit, true]
+              : [false, results.rows.length > limit];
 
           // Remove the extra value used to check for additional values.
-          if (results.length > limit) results.pop();
+          if (results.rows.length > limit) results.rows.pop();
 
           // Reorder the results if we changed the order in the query.
-          if (direction === 'prev') results.reverse();
+          if (direction === 'prev') results.rows.reverse();
 
           // Map results into Relay spec format
-          const edges = results.map((result) => ({
+          const edges = results.rows.map((result) => ({
             cursor: encodeCursor(result, order),
             node: result
           }));
 
           // Return page and cursor info.
           return {
+            totalCount: results.count,
             edges,
             pageInfo: {
               hasPreviousPage,

--- a/relay.test.js
+++ b/relay.test.js
@@ -37,6 +37,7 @@ test('Paginates correctly on primary key ordered ASC', async () => {
 
   // UP THROUGH PAGES
   page = await Test.paginate({ first: 2 });
+  expect(page.totalCount).toBe(5);
   expect(page.edges.length).toBe(2);
   expect(page.edges[0].node.id).toBe(1);
   expect(page.edges[1].node.id).toBe(2);
@@ -46,6 +47,7 @@ test('Paginates correctly on primary key ordered ASC', async () => {
   expect(page.pageInfo.hasNextPage).toBe(true);
 
   page = await Test.paginate({ first: 2, after: page.pageInfo.endCursor });
+  expect(page.totalCount).toBe(3);
   expect(page.edges.length).toBe(2);
   expect(page.edges[0].node.id).toBe(3);
   expect(page.edges[1].node.id).toBe(4);
@@ -55,6 +57,7 @@ test('Paginates correctly on primary key ordered ASC', async () => {
   expect(page.pageInfo.hasNextPage).toBe(true);
 
   page = await Test.paginate({ first: 2, after: page.pageInfo.endCursor });
+  expect(page.totalCount).toBe(1);
   expect(page.edges.length).toBe(1);
   expect(page.edges[0].node.id).toBe(5);
   expect(page.pageInfo.startCursor).not.toBeNull();
@@ -64,6 +67,7 @@ test('Paginates correctly on primary key ordered ASC', async () => {
 
   // DOWN THROUGH PAGES
   page = await Test.paginate({ last: 2, before: page.pageInfo.startCursor });
+  expect(page.totalCount).toBe(4);
   expect(page.edges.length).toBe(2);
   expect(page.edges[0].node.id).toBe(3);
   expect(page.edges[1].node.id).toBe(4);
@@ -73,6 +77,7 @@ test('Paginates correctly on primary key ordered ASC', async () => {
   expect(page.pageInfo.hasNextPage).toBe(true);
 
   page = await Test.paginate({ last: 2, before: page.pageInfo.startCursor });
+  expect(page.totalCount).toBe(2);
   expect(page.edges.length).toBe(2);
   expect(page.edges[0].node.id).toBe(1);
   expect(page.edges[1].node.id).toBe(2);
@@ -91,6 +96,7 @@ test('Paginates correctly on non primary key ordered ASC', async () => {
 
   // UP THROUGH PAGES
   page = await Test.paginate({ first: 2, order });
+  expect(page.totalCount).toBe(5);
   expect(page.edges.length).toBe(2);
   expect(page.edges[0].node.id).toBe(2);
   expect(page.edges[1].node.id).toBe(3);
@@ -100,6 +106,7 @@ test('Paginates correctly on non primary key ordered ASC', async () => {
   expect(page.pageInfo.hasNextPage).toBe(true);
 
   page = await Test.paginate({ first: 2, order, after: page.pageInfo.endCursor });
+  expect(page.totalCount).toBe(3);
   expect(page.edges.length).toBe(2);
   expect(page.edges[0].node.id).toBe(1);
   expect(page.edges[1].node.id).toBe(5);
@@ -109,6 +116,7 @@ test('Paginates correctly on non primary key ordered ASC', async () => {
   expect(page.pageInfo.hasNextPage).toBe(true);
 
   page = await Test.paginate({ first: 2, order, after: page.pageInfo.endCursor });
+  expect(page.totalCount).toBe(1);
   expect(page.edges.length).toBe(1);
   expect(page.edges[0].node.id).toBe(4);
   expect(page.pageInfo.startCursor).not.toBeNull();
@@ -118,6 +126,7 @@ test('Paginates correctly on non primary key ordered ASC', async () => {
 
   // DOWN THROUGH PAGES
   page = await Test.paginate({ last: 2, order, before: page.pageInfo.startCursor });
+  expect(page.totalCount).toBe(4);
   expect(page.edges.length).toBe(2);
   expect(page.edges[0].node.id).toBe(1);
   expect(page.edges[1].node.id).toBe(5);
@@ -127,6 +136,7 @@ test('Paginates correctly on non primary key ordered ASC', async () => {
   expect(page.pageInfo.hasNextPage).toBe(true);
 
   page = await Test.paginate({ last: 2, order, before: page.pageInfo.startCursor });
+  expect(page.totalCount).toBe(2);
   expect(page.edges.length).toBe(2);
   expect(page.edges[0].node.id).toBe(2);
   expect(page.edges[1].node.id).toBe(3);
@@ -145,6 +155,7 @@ test('Paginates correctly on primary key ordered DESC', async () => {
 
   // UP THROUGH PAGES
   page = await Test.paginate({ first: 2, order });
+  expect(page.totalCount).toBe(5);
   expect(page.edges.length).toBe(2);
   expect(page.edges[0].node.id).toBe(5);
   expect(page.edges[1].node.id).toBe(4);
@@ -154,6 +165,7 @@ test('Paginates correctly on primary key ordered DESC', async () => {
   expect(page.pageInfo.hasNextPage).toBe(true);
 
   page = await Test.paginate({ first: 2, order, after: page.pageInfo.endCursor });
+  expect(page.totalCount).toBe(3);
   expect(page.edges.length).toBe(2);
   expect(page.edges[0].node.id).toBe(3);
   expect(page.edges[1].node.id).toBe(2);
@@ -163,6 +175,7 @@ test('Paginates correctly on primary key ordered DESC', async () => {
   expect(page.pageInfo.hasNextPage).toBe(true);
 
   page = await Test.paginate({ first: 2, order, after: page.pageInfo.endCursor });
+  expect(page.totalCount).toBe(1);
   expect(page.edges.length).toBe(1);
   expect(page.edges[0].node.id).toBe(1);
   expect(page.pageInfo.startCursor).not.toBeNull();
@@ -172,6 +185,7 @@ test('Paginates correctly on primary key ordered DESC', async () => {
 
   // DOWN THROUGH PAGES
   page = await Test.paginate({ last: 2, order, before: page.pageInfo.startCursor });
+  expect(page.totalCount).toBe(4);
   expect(page.edges.length).toBe(2);
   expect(page.edges[0].node.id).toBe(3);
   expect(page.edges[1].node.id).toBe(2);
@@ -181,6 +195,7 @@ test('Paginates correctly on primary key ordered DESC', async () => {
   expect(page.pageInfo.hasNextPage).toBe(true);
 
   page = await Test.paginate({ last: 2, order, before: page.pageInfo.startCursor });
+  expect(page.totalCount).toBe(2);
   expect(page.edges.length).toBe(2);
   expect(page.edges[0].node.id).toBe(5);
   expect(page.edges[1].node.id).toBe(4);
@@ -199,6 +214,7 @@ test('Paginates correctly on non primary key ordered DESC', async () => {
 
   // UP THROUGH PAGES
   page = await Test.paginate({ first: 2, order });
+  expect(page.totalCount).toBe(5);
   expect(page.edges.length).toBe(2);
   expect(page.edges[0].node.id).toBe(4);
   expect(page.edges[1].node.id).toBe(5);
@@ -208,6 +224,7 @@ test('Paginates correctly on non primary key ordered DESC', async () => {
   expect(page.pageInfo.hasNextPage).toBe(true);
 
   page = await Test.paginate({ first: 2, order, after: page.pageInfo.endCursor });
+  expect(page.totalCount).toBe(3);
   expect(page.edges.length).toBe(2);
   expect(page.edges[0].node.id).toBe(1);
   expect(page.edges[1].node.id).toBe(3);
@@ -217,6 +234,7 @@ test('Paginates correctly on non primary key ordered DESC', async () => {
   expect(page.pageInfo.hasNextPage).toBe(true);
 
   page = await Test.paginate({ first: 2, order, after: page.pageInfo.endCursor });
+  expect(page.totalCount).toBe(1);
   expect(page.edges.length).toBe(1);
   expect(page.edges[0].node.id).toBe(2);
   expect(page.pageInfo.startCursor).not.toBeNull();
@@ -226,6 +244,7 @@ test('Paginates correctly on non primary key ordered DESC', async () => {
 
   // DOWN THROUGH PAGES
   page = await Test.paginate({ last: 2, order, before: page.pageInfo.startCursor });
+  expect(page.totalCount).toBe(4);
   expect(page.edges.length).toBe(2);
   expect(page.edges[0].node.id).toBe(1);
   expect(page.edges[1].node.id).toBe(3);
@@ -235,6 +254,7 @@ test('Paginates correctly on non primary key ordered DESC', async () => {
   expect(page.pageInfo.hasNextPage).toBe(true);
 
   page = await Test.paginate({ last: 2, order, before: page.pageInfo.startCursor });
+  expect(page.totalCount).toBe(2);
   expect(page.edges.length).toBe(2);
   expect(page.edges[0].node.id).toBe(4);
   expect(page.edges[1].node.id).toBe(5);
@@ -253,6 +273,7 @@ test('Paginates correctly on non unique field ordered ASC', async () => {
 
   // UP THROUGH PAGES
   page = await Test.paginate({ first: 2, order });
+  expect(page.totalCount).toBe(5);
   expect(page.edges.length).toBe(2);
   expect(page.edges[0].node.id).toBe(1);
   expect(page.edges[1].node.id).toBe(5);
@@ -262,6 +283,7 @@ test('Paginates correctly on non unique field ordered ASC', async () => {
   expect(page.pageInfo.hasNextPage).toBe(true);
 
   page = await Test.paginate({ first: 2, order, after: page.pageInfo.endCursor });
+  expect(page.totalCount).toBe(3);
   expect(page.edges.length).toBe(2);
   expect(page.edges[0].node.id).toBe(2);
   expect(page.edges[1].node.id).toBe(3);
@@ -271,6 +293,7 @@ test('Paginates correctly on non unique field ordered ASC', async () => {
   expect(page.pageInfo.hasNextPage).toBe(true);
 
   page = await Test.paginate({ first: 2, order, after: page.pageInfo.endCursor });
+  expect(page.totalCount).toBe(1);
   expect(page.edges.length).toBe(1);
   expect(page.edges[0].node.id).toBe(4);
   expect(page.pageInfo.startCursor).not.toBeNull();
@@ -280,6 +303,7 @@ test('Paginates correctly on non unique field ordered ASC', async () => {
 
   // DOWN THROUGH PAGES
   page = await Test.paginate({ last: 2, order, before: page.pageInfo.startCursor });
+  expect(page.totalCount).toBe(4);
   expect(page.edges.length).toBe(2);
   expect(page.edges[0].node.id).toBe(2);
   expect(page.edges[1].node.id).toBe(3);
@@ -289,6 +313,7 @@ test('Paginates correctly on non unique field ordered ASC', async () => {
   expect(page.pageInfo.hasNextPage).toBe(true);
 
   page = await Test.paginate({ last: 2, order, before: page.pageInfo.startCursor });
+  expect(page.totalCount).toBe(2);
   expect(page.edges.length).toBe(2);
   expect(page.edges[0].node.id).toBe(1);
   expect(page.edges[1].node.id).toBe(5);
@@ -307,6 +332,7 @@ test('Paginates correctly on non unique field ordered DESC', async () => {
 
   // UP THROUGH PAGES
   page = await Test.paginate({ first: 2, order });
+  expect(page.totalCount).toBe(5);
   expect(page.edges.length).toBe(2);
   expect(page.edges[0].node.id).toBe(2);
   expect(page.edges[1].node.id).toBe(3);
@@ -316,6 +342,7 @@ test('Paginates correctly on non unique field ordered DESC', async () => {
   expect(page.pageInfo.hasNextPage).toBe(true);
 
   page = await Test.paginate({ first: 2, order, after: page.pageInfo.endCursor });
+  expect(page.totalCount).toBe(3);
   expect(page.edges.length).toBe(2);
   expect(page.edges[0].node.id).toBe(4);
   expect(page.edges[1].node.id).toBe(1);
@@ -325,6 +352,7 @@ test('Paginates correctly on non unique field ordered DESC', async () => {
   expect(page.pageInfo.hasNextPage).toBe(true);
 
   page = await Test.paginate({ first: 2, order, after: page.pageInfo.endCursor });
+  expect(page.totalCount).toBe(1);
   expect(page.edges.length).toBe(1);
   expect(page.edges[0].node.id).toBe(5);
   expect(page.pageInfo.startCursor).not.toBeNull();
@@ -334,6 +362,7 @@ test('Paginates correctly on non unique field ordered DESC', async () => {
 
   // DOWN THROUGH PAGES
   page = await Test.paginate({ last: 2, order, before: page.pageInfo.startCursor });
+  expect(page.totalCount).toBe(4);
   expect(page.edges.length).toBe(2);
   expect(page.edges[0].node.id).toBe(4);
   expect(page.edges[1].node.id).toBe(1);
@@ -343,6 +372,7 @@ test('Paginates correctly on non unique field ordered DESC', async () => {
   expect(page.pageInfo.hasNextPage).toBe(true);
 
   page = await Test.paginate({ last: 2, order, before: page.pageInfo.startCursor });
+  expect(page.totalCount).toBe(2);
   expect(page.edges.length).toBe(2);
   expect(page.edges[0].node.id).toBe(2);
   expect(page.edges[1].node.id).toBe(3);
@@ -359,6 +389,7 @@ test('Paginates correctly when findAll attributes are provided', async () => {
 
   // UP THROUGH PAGES
   page = await Test.paginate({ first: 2, attributes: ['id'] });
+  expect(page.totalCount).toBe(5);
   expect(page.edges.length).toBe(2);
   expect(page.edges[0].node.id).toBe(1);
   expect(page.edges[1].node.id).toBe(2);
@@ -370,6 +401,7 @@ test('Paginates correctly when findAll attributes are provided', async () => {
   expect(page.pageInfo.hasNextPage).toBe(true);
 
   page = await Test.paginate({ first: 2, attributes: ['id'], after: page.pageInfo.endCursor });
+  expect(page.totalCount).toBe(3);
   expect(page.edges.length).toBe(2);
   expect(page.edges[0].node.id).toBe(3);
   expect(page.edges[1].node.id).toBe(4);
@@ -381,6 +413,7 @@ test('Paginates correctly when findAll attributes are provided', async () => {
   expect(page.pageInfo.hasNextPage).toBe(true);
 
   page = await Test.paginate({ first: 2, attributes: ['id'], after: page.pageInfo.endCursor });
+  expect(page.totalCount).toBe(1);
   expect(page.edges.length).toBe(1);
   expect(page.edges[0].node.id).toBe(5);
   expect(page.edges[0].node.extra1).toBeUndefined();
@@ -391,6 +424,7 @@ test('Paginates correctly when findAll attributes are provided', async () => {
 
   // DOWN THROUGH PAGES
   page = await Test.paginate({ last: 2, attributes: ['id'], before: page.pageInfo.startCursor });
+  expect(page.totalCount).toBe(4);
   expect(page.edges.length).toBe(2);
   expect(page.edges[0].node.id).toBe(3);
   expect(page.edges[1].node.id).toBe(4);
@@ -402,6 +436,7 @@ test('Paginates correctly when findAll attributes are provided', async () => {
   expect(page.pageInfo.hasNextPage).toBe(true);
 
   page = await Test.paginate({ last: 2, attributes: ['id'], before: page.pageInfo.startCursor });
+  expect(page.totalCount).toBe(2);
   expect(page.edges.length).toBe(2);
   expect(page.edges[0].node.id).toBe(1);
   expect(page.edges[1].node.id).toBe(2);


### PR DESCRIPTION
Hello,

I made this change as my client needed to display the number of resulting records. I know that its not exactly in the Relay specification, but I reckon that I could be useful. Otherwise feel free to reject the PR